### PR TITLE
feat: Update network module version to 0.0.8

### DIFF
--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -72,7 +72,7 @@ publishing {
         create<MavenPublication>("release") {
             groupId = "com.dubizzle"  // Change to your GitHub username
             artifactId = "network"             // Change to your library name
-            version = System.getenv("VERSION_NAME")?.plus("_beta") ?: "0.0.4"
+            version = System.getenv("VERSION_NAME")?.plus("_beta") ?: "0.0.8"
 
             afterEvaluate {
                 from(components["release"])


### PR DESCRIPTION
This commit updates the version of the network module from 0.0.4 to 0.0.8.

-   **network/build.gradle.kts:**
    -   Changes the default `version` for the `release` Maven publication from `0.0.4` to `0.0.8`.
    -  The version in the maven publication block has been increased to `0.0.8`.